### PR TITLE
http://reddotrubyconf.com/cfp redirects to cfp app

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: "home#index"
   get "/code-of-conduct", to: "home#code_of_conduct"
-
+  get "/cfp", to: redirect("https://rdrc-cfp.herokuapp.com/events/reddotrubyconf")
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   # Serve websocket cable requests in-process


### PR DESCRIPTION
http://reddotrubyconf.com/cfp => https://rdrc-cfp.herokuapp.com/events/reddotrubyconf

Can tweet this URL and eaiser to remember than https://rdrc-cfp.herokuapp.com/events/reddotrubyconf.
