### PR TITLE
Trying to fix action cable connection on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,8 +39,9 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Action Cable endpoint configuration
+  config.web_socket_server_url = "wss://www.reddotrubyconf.com/cable"
   config.action_cable.url = "wss://www.reddotrubyconf.com/cable"
-  config.action_cable.allowed_request_origins = [ "http://www.reddotrubyconf.com", /http:\/\/www.reddotrubyconf.com.*/ ]
+  config.action_cable.allowed_request_origins = [ "https://www.reddotrubyconf.com", /https:\/\/www.reddotrubyconf.com.*/, "http://www.reddotrubyconf.com", /http:\/\/www.reddotrubyconf.com.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true


### PR DESCRIPTION
I noticed that ActionCable works find on local (after increasing size of Redis pool), so the issue is most probably on production. Since I don't have access to the logs, I am guessing that it's an issue with SSL. So I tried following step by step the Heroku guide to make sure it works: https://blog.heroku.com/archives/2016/5/9/real_time_rails_implementing_websockets_in_rails_5_with_action_cable
